### PR TITLE
Don't use prefix on leaf commands

### DIFF
--- a/src/default.nix
+++ b/src/default.nix
@@ -19,7 +19,7 @@
   in
     mkCase subcommand (
       if lib.isString value || lib.isStorePath value
-      then mkRunCommand value (styles.defaultCommandColor prefixWithSubcommand)
+      then mkRunCommand false value (styles.defaultCommandColor prefixWithSubcommand)
       else mkOptions prefixWithSubcommand value
     );
 

--- a/src/mkAllHandler.nix
+++ b/src/mkAllHandler.nix
@@ -53,7 +53,7 @@
       ]
       ++ (
         util.indent (
-          mkRunCommand commandsByName."${name}" (prefixStyle pos (padName name))
+          mkRunCommand true commandsByName."${name}" (prefixStyle pos (padName name))
         )
       )
       ++ [

--- a/src/mkHelp.nix
+++ b/src/mkHelp.nix
@@ -12,8 +12,10 @@
     then ["${styles.branch option}: ${styles.command value}"]
     else [(styles.leaf option)] ++ (mkHelpOptions value);
 
-  mkHelpOptions = options:
-    util.indent (util.concatMapAttrsToList mkHelpOption options);
+  mkHelpOptions = options: let
+    options' = builtins.removeAttrs options ["_noAll"];
+  in
+    util.indent (util.concatMapAttrsToList mkHelpOption options');
 in
   cmd: options:
     map echo (

--- a/src/mkRunCommand.nix
+++ b/src/mkRunCommand.nix
@@ -3,7 +3,10 @@
 
   prefixStr = prefix: " ${prefix} ${ansi.style [ansi.fgDarkGrey] "│"} ";
 in
-  cmd: prefix: [
-    "${cmd} \"$@\" 2>&1 | sed \"s/^/$(printf \"${prefixStr prefix}\")/\""
-    "exit \${PIPESTATUS[0]}"
-  ]
+  prefixOutputs: cmd: prefix:
+    if prefixOutputs
+    then [
+      "${cmd} \"$@\" 2>&1 | sed \"s/^/$(printf \"${prefixStr prefix}\")/\""
+      "exit \${PIPESTATUS[0]}"
+    ]
+    else ["${cmd}"]


### PR DESCRIPTION
Now `all` commands default to using the ansi prefixing, while directly invoking leaf commands does not

depends on #3 